### PR TITLE
Fix `Stream::read($length)` implementation

### DIFF
--- a/src/Stream.php
+++ b/src/Stream.php
@@ -163,10 +163,6 @@ class Stream implements StreamInterface
             return fread($this->socket, $length);
         }
 
-        if ($this->getSize() < ($this->readed + $length)) {
-            throw new StreamException('Cannot read more than %s', $this->getSize() - $this->readed);
-        }
-
         if ($this->getSize() === $this->readed) {
             return '';
         }

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -144,4 +144,14 @@ class StreamTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse(is_resource($socket));
     }
+
+    public function testRead()
+    {
+        $stream = $this->createSocket("Body");
+
+        $this->assertEquals("Bod", $stream->read(3));
+        $this->assertEquals("y", $stream->read(3));
+
+        $stream->close();
+    }
 }


### PR DESCRIPTION
When `$length` value exceeds the stream eof, the remaining stream content
must be returned.

See #13 