### PR TITLE
Add Content-Length when request body size is known

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -69,6 +69,10 @@ class Client implements HttpClient
             $request = $request->withHeader('Connection', 'close');
         }
 
+        if (!$request->hasHeader('Content-Length') && false != ($bodySize = $request->getBody()->getSize())) {
+            $request = $request->withHeader('Content-Length', $bodySize);
+        }
+
         if (null === $remote) {
             $remote = $this->determineRemoteFromRequest($request);
         }


### PR DESCRIPTION
If a Psr7\Request has a body set and its size is known, automatically add the correct Content-Length header.

When POSTing data at present with _php-http/socket-client_, most web servers discard the request body because the required Content-Length header is not set. It can be set manually, but all other _php-http_ clients appear to set set it automatically. In general I think the expectation is that the client will set this header. Below is a code example of the original issue.

In some instances a Request may have a body but its size is not known; which this doesn't address. Support for `Transfer-Encoding: chunked` will probably need adding to support this.

```PHP
<?php

include_once( '../vendor/autoload.php' );

use GuzzleHttp\Psr7\Request;
use Http\Message\MessageFactory\GuzzleMessageFactory;

$client = new \Http\Client\Socket\Client( new GuzzleMessageFactory );

$url = 'http://requestb.in/xag5caxa';
$body = 'Testing';

//-----------------------------------------------

// Server does not see $body

$request = new Request(
    'POST',
    $url,
    [],
    $body
);

$client->sendRequest( $request );

//-----------------------------------------------

// Server receives $body

$request = new Request(
    'POST',
    $url,
    [
        'Content-Length' => strlen($body),
    ],
    $body
);

$client->sendRequest( $request );
```