### PR TITLE
Make sure we always close the socket

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -82,10 +82,8 @@ class Client implements HttpClient
         try {
             $this->writeRequest($socket, $request, $this->config['write_buffer_size']);
             $response = $this->readResponse($request, $socket);
-        } catch (\Exception $e) {
+        } finally {
             $this->closeSocket($socket);
-
-            throw $e;
         }
 
         return $response;


### PR DESCRIPTION
I found this by accident. We should make sure to always close the socket even if the request doesn't fail. 

Since we dropped support for 5.4 we can use the `finally` keyword. 
