### PR TITLE
Remove message factory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,15 +12,14 @@
         "php": "^5.5 || ^7.0",
         "symfony/options-resolver": "^2.6 || ^3.0",
         "php-http/httplug": "^1.0",
-        "php-http/message-factory": "^1.0.2",
-        "php-http/discovery": "^1.0"
+        "guzzlehttp/psr7": "^1.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",
-        "guzzlehttp/psr7": "^1.2",
-        "php-http/client-integration-tests": "^0.5.1",
-        "php-http/message": "^1.0",
-        "php-http/client-common": "^1.0"
+        "php-http/adapter-integration-tests": "~0.3.1",
+        "php-http/client-common": "^1.0",
+        "php-http/message-factory": "^1.0.2",
+        "puli/composer-plugin": "1.0.0-beta9"
     },
     "provide": {
         "php-http/client-implementation": "1.0"

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",
-        "php-http/adapter-integration-tests": "~0.3.1",
-        "php-http/client-common": "^1.0",
+        "php-http/client-integration-tests": "^0.5.1",
         "php-http/message-factory": "^1.0.2",
-        "puli/composer-plugin": "1.0.0-beta9"
+        "php-http/message": "^1.0",
+        "php-http/client-common": "^1.0"
     },
     "provide": {
         "php-http/client-implementation": "1.0"

--- a/src/Client.php
+++ b/src/Client.php
@@ -22,7 +22,7 @@ class Client implements HttpClient
     use ResponseReader;
 
     /**
-     * Config of this client
+     * Config of this client.
      *
      * @var array
      */
@@ -39,7 +39,7 @@ class Client implements HttpClient
     /**
      * Constructor.
      *
-     * @param array           $config          {
+     * @param array $config {
      *
      *    @var string $remote_socket          Remote entrypoint (can be a tcp or unix domain address)
      *    @var int    $timeout                Timeout before canceling request
@@ -49,7 +49,8 @@ class Client implements HttpClient
      *    @var int    $write_buffer_size      Buffer when writing the request body, defaults to 8192
      *    @var int    $ssl_method             Crypto method for ssl/tls, see PHP doc, defaults to STREAM_CRYPTO_METHOD_TLS_CLIENT
      * }
-     * @param array            $deprecatedConfig Use for BC with old versions
+     *
+     * @param array $deprecatedConfig Use for BC with old versions
      */
     public function __construct($config = [], array $deprecatedConfig = [])
     {

--- a/src/ResponseReader.php
+++ b/src/ResponseReader.php
@@ -2,8 +2,8 @@
 
 namespace Http\Client\Socket;
 
+use GuzzleHttp\Psr7\Response;
 use Http\Client\Exception\NetworkException;
-use Http\Message\ResponseFactory;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -16,11 +16,6 @@ use Psr\Http\Message\ResponseInterface;
  */
 trait ResponseReader
 {
-    /**
-     * @var ResponseFactory For creating response
-     */
-    protected $responseFactory;
-
     /**
      * Read a response from a socket.
      *
@@ -77,7 +72,7 @@ trait ResponseReader
                 : '';
         }
 
-        $response = $this->responseFactory->createResponse($status, $reason, $responseHeaders, null, $protocol);
+        $response = new Response($status, $responseHeaders, null, $protocol, $reason);
         $stream = $this->createStream($socket, $response);
 
         return $response->withBody($stream);

--- a/tests/SocketHttpClientTest.php
+++ b/tests/SocketHttpClientTest.php
@@ -12,7 +12,7 @@ class SocketHttpClientTest extends BaseTestCase
     {
         $messageFactory = new GuzzleMessageFactory();
 
-        return new HttpMethodsClient(new SocketHttpClient($messageFactory, $options), $messageFactory);
+        return new HttpMethodsClient(new SocketHttpClient($options), $messageFactory);
     }
 
     public function testTcpSocketDomain()


### PR DESCRIPTION
IMO I don't need it here, the standard (PSR7) is too contraignous to have a very different implementation on the message part (Request / Response) and since we use our own stream (no stream factory needed), using a message factory here is over engineering.

WDYT ? ping @sagikazarmark @dbu @Nyholm 
