### PR TITLE
TLS v1 is not accepted anymore

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -31,7 +31,7 @@ class Client implements HttpClient
         'stream_context_param' => [],
         'ssl' => null,
         'write_buffer_size' => 8192,
-        'ssl_method' => STREAM_CRYPTO_METHOD_TLS_CLIENT,
+        'ssl_method' => STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT,
     ];
 
     /**
@@ -46,7 +46,7 @@ class Client implements HttpClient
      *    @var array  $stream_context_param   Context params as defined in the PHP documentation
      *    @var bool   $ssl                    Use ssl, default to scheme from request, false if not present
      *    @var int    $write_buffer_size      Buffer when writing the request body, defaults to 8192
-     *    @var int    $ssl_method             Crypto method for ssl/tls, see PHP doc, defaults to STREAM_CRYPTO_METHOD_TLS_CLIENT
+     *    @var int    $ssl_method             Crypto method for ssl/tls, see PHP doc, defaults to STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT
      * }
      */
     public function __construct(ResponseFactory $responseFactory = null, array $config = [])

--- a/tests/server/tcp-ssl-server-client.php
+++ b/tests/server/tcp-ssl-server-client.php
@@ -15,7 +15,7 @@ stream_socket_enable_crypto($socketServer, false);
 
 $client       = stream_socket_accept($socketServer);
 stream_set_blocking($client, true);
-stream_socket_enable_crypto($client, true, STREAM_CRYPTO_METHOD_TLS_SERVER);
+stream_socket_enable_crypto($client, true, STREAM_CRYPTO_METHOD_TLSv1_2_SERVER);
 
 // Verify client certificate
 $name = null;

--- a/tests/server/tcp-ssl-server.php
+++ b/tests/server/tcp-ssl-server.php
@@ -13,7 +13,7 @@ stream_socket_enable_crypto($socketServer, false);
 
 $client       = stream_socket_accept($socketServer);
 stream_set_blocking($client, true);
-if (@stream_socket_enable_crypto($client, true, STREAM_CRYPTO_METHOD_TLS_SERVER)) {
+if (@stream_socket_enable_crypto($client, true, STREAM_CRYPTO_METHOD_TLSv1_2_SERVER)) {
     fwrite($client, str_replace("\n", "\r\n", <<<EOR
 HTTP/1.1 200 OK
 Content-Type: text/plain


### PR DESCRIPTION
I got errors like that all the time since the servers I contact updated their lib.

> OpenSSL Error messages:
error:1409442E:SSL routines:SSL3_READ_BYTES:tlsv1 alert protocol version