### PR TITLE
fixed wrong call of trigger_error()

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -56,7 +56,7 @@ class Client implements HttpClient
             return;
         }
 
-        @trigger_error(E_USER_DEPRECATED, 'Passing a Psr\Http\Message\ResponseFactoryInterface and a Psr\Http\Message\StreamFactoryInterface to SocketClient is deprecated, and will be removed in 3.0, you should only pass config options.');
+        @trigger_error('Passing a Psr\Http\Message\ResponseFactoryInterface and a Psr\Http\Message\StreamFactoryInterface to SocketClient is deprecated, and will be removed in 3.0, you should only pass config options.', E_USER_DEPRECATED);
 
         $this->config = $this->configure($config);
     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?         | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT


#### What's in this PR?

Your call to `trigger_error()` in Client.php, line 63 is wrong, as the parameters $error_msg and $error_type are switched. This lead to the following error in PHP 7.4:

```
PHP Error: trigger_error() expects parameter 2 to be int, string given, line 63 in /[...]/vendor/php-http/socket-client/src/Client.php
```

This PR fixes this issue by bringing the parameters into correct order.

Merging and releasing 2.0.1 is kindly requested.
