### PR TITLE
Add php 8 support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2.0.3
+
+ * Add php 8 compatibility
+
 ## 2.0.2
 
  * Fixed composer "provide" section to say that we provide `psr/http-client-implementation`

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": ">=7.1 ",
         "nyholm/psr7": "^1.3",
         "php-http/httplug": "^2.0",
         "psr/http-client": "^1.0",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?         | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT


#### What's in this PR?

Change requirement for php to take php 8 into account.

#### Why?

As php 8 release gets closer it can be very useful to test packages for compatibility ahead of the release.


#### To Do

Enable travis testing
