### PR TITLE
Added instructions for generating ssl files on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,12 @@ $ ./vendor/bin/http_test_server > /dev/null 2>&1 &
 Then generate ssh certificates:
 
 ```bash
-$ cd ./tests/server/ssl 
+$ cd ./tests/server/ssl
 $ ./generate.sh
-$ cd ../../../ 
+$ cd ../../../
 ```
+
+Note: If you are running this on macOS and get the following error: "Error opening CA Private Key privkey.pem", check [this](ssl-macOS.md) file.
 
 Now run the test suite:
 

--- a/ssl-macOS.md
+++ b/ssl-macOS.md
@@ -1,0 +1,58 @@
+# Generating SSL Certificates on macOS
+
+When generating SSL Certificates on macOS, you must ensure that you're using brew's openssl binary and not the one provided by the OS.
+
+To do that, find out where your openssl is installed by running:
+
+```bash
+$ brew info openssl
+```
+
+You should see something like this:
+
+```
+openssl@1.1: stable 1.1.1i (bottled) [keg-only]
+Cryptography and SSL/TLS Toolkit
+https://openssl.org/
+/usr/local/Cellar/openssl@1.1/1.1.1i (8,067 files, 18.5MB)
+  Poured from bottle on 2020-12-11 at 11:31:46
+From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/openssl@1.1.rb
+License: OpenSSL
+==> Caveats
+A CA file has been bootstrapped using certificates from the system
+keychain. To add additional certificates, place .pem files in
+  /usr/local/etc/openssl@1.1/certs
+
+and run
+  /usr/local/opt/openssl@1.1/bin/c_rehash
+
+openssl@1.1 is keg-only, which means it was not symlinked into /usr/local,
+because macOS provides LibreSSL.
+
+If you need to have openssl@1.1 first in your PATH run:
+  echo 'export PATH="/usr/local/opt/openssl@1.1/bin:$PATH"' >> /Users/flavio/.bash_profile
+
+For compilers to find openssl@1.1 you may need to set:
+  export LDFLAGS="-L/usr/local/opt/openssl@1.1/lib"
+  export CPPFLAGS="-I/usr/local/opt/openssl@1.1/include"
+
+For pkg-config to find openssl@1.1 you may need to set:
+  export PKG_CONFIG_PATH="/usr/local/opt/openssl@1.1/lib/pkgconfig"
+
+==> Analytics
+install: 855,315 (30 days), 2,356,331 (90 days), 7,826,269 (365 days)
+install-on-request: 139,236 (30 days), 373,801 (90 days), 1,120,685 (365 days)
+build-error: 0 (30 days)
+```
+
+The important part is this:
+
+> echo 'export PATH="/usr/local/opt/openssl@1.1/bin:$PATH"' >> /Users/flavio/.bash_profile
+
+Instead of running `./tests/server/ssl/generate.sh`, you should instead run:
+
+```bash
+$ PATH="/usr/local/opt/openssl@1.1/bin ./tests/server/ssl/generate.sh
+```
+
+You should now be good to go.


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?         | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| Documentation   | if this is a new feature, link to pull request in https://github.com/php-http/documentation that adds relevant documentation
| License         | MIT


#### What's in this PR?

This PR adds instructions for generating ssl files on macOS, required to run the library's test suite.


#### Why?

When trying to generate ssl files on macOS Catalina (10.15.7), openssl fails to read the CA private key (check below), this PR adds instructions on how to workaround that problem in a very straightforward way.

```
$ ./generate.sh 
Generating a 2048 bit RSA private key
......................+++
............+++
writing new private key to stdout
-----BEGIN ENCRYPTED PRIVATE KEY-----
[REDACTED]
-----END ENCRYPTED PRIVATE KEY-----
-----
Generating RSA private key, 2048 bit long modulus
..........................+++
......+++
e is 65537 (0x10001)
Signature ok
subject=/C=FR/ST=Ile-de-France/L=Paris/O=PHP-HTTP/CN=socket-adapter
Getting CA Private Key
Error opening CA Private Key privkey.pem
4361031276:error:02FFF002:system library:func(4095):No such file or directory:/AppleInternal/BuildRoot/Library/Caches/com.apple.xbs/Sources/libressl/libressl-47.140.1/libressl-2.8/crypto/bio/bss_file.c:255:fopen('privkey.pem', 'r')
4361031276:error:20FFF002:BIO routines:CRYPTO_internal:system lib:/AppleInternal/BuildRoot/Library/Caches/com.apple.xbs/Sources/libressl/libressl-47.140.1/libressl-2.8/crypto/bio/bss_file.c:257:
unable to load CA Private Key
```


#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)

^ Have not done any of these as I don't think it applies to this case.