### PR TITLE
Relative/Absolute path improvement for generate.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,7 @@ $ ./vendor/bin/http_test_server > /dev/null 2>&1 &
 Then generate ssh certificates:
 
 ```bash
-$ cd ./tests/server/ssl
-$ ./generate.sh
-$ cd ../../../
+$ composer gen-ssl
 ```
 
 Note: If you are running this on macOS and get the following error: "Error opening CA Private Key privkey.pem", check [this](ssl-macOS.md) file.

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
         "cs-check": "vendor/bin/php-cs-fixer fix --dry-run",
         "cs-fix": "vendor/bin/php-cs-fixer fix",
         "test": "vendor/bin/phpunit",
-        "test-ci": "vendor/bin/phpunit --coverage-clover build/coverage.xml"
+        "test-ci": "vendor/bin/phpunit --coverage-clover build/coverage.xml",
+        "gen-ssl": "tests/server/ssl/generate.sh"
     },
     "extra": {
         "branch-alias": {

--- a/tests/server/ssl/generate.sh
+++ b/tests/server/ssl/generate.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+set -eo pipefail
+
+cd $(dirname $0)
+
 C=FR
 ST=Ile-de-France
 L=Paris


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?         | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| Documentation   | if this is a new feature, link to pull request in https://github.com/php-http/documentation that adds relevant documentation
| License         | MIT


#### What's in this PR?

This PR does 3 simple changes:

1. It removes the need of changing the current directory to `tests/server/ssl` before executing `generate.sh`;
2. It adds the flags below to the bash script in order to make it fail faster in case of an error;
3. It creates the convenience composer script `gen-ssl`, making it even easier than before.

Script flags:
`-e`: Exit immediately if a pipeline, which may consist of a single simple command, a list, or a compound command returns a non-zero status. [reference](https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html)

`-o pipefail`: If set, the return value of a pipeline is the value of the last (rightmost) command to exit with a non-zero status, or zero if all commands in the pipeline exit successfully. [reference](https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html)

#### Why?

The idea behind this PR is to streamline the newcomer contributor experience.

#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)

^ No changes were made to the code itself, thus I don't think I should check any of those.