### PR TITLE
Migrate deprecated test annotations to assertions

### DIFF
--- a/tests/SocketHttpClientTest.php
+++ b/tests/SocketHttpClientTest.php
@@ -25,11 +25,10 @@ class SocketHttpClientTest extends BaseTestCase
         $this->assertEquals(200, $response->getStatusCode());
     }
 
-    /**
-     * @expectedException \Http\Client\Socket\Exception\NetworkException
-     */
     public function testNoRemote()
     {
+        $this->expectException(\Http\Client\Socket\Exception\NetworkException::class);
+
         $client = $this->createClient();
         $client->get('/', []);
     }
@@ -54,11 +53,10 @@ class SocketHttpClientTest extends BaseTestCase
         $this->assertEquals(200, $response->getStatusCode());
     }
 
-    /**
-     * @expectedException \Http\Client\Socket\Exception\NetworkException
-     */
     public function testBrokenSocket()
     {
+        $this->expectException(\Http\Client\Socket\Exception\NetworkException::class);
+
         $this->startServer('tcp-bugous-server');
         $client = $this->createClient(['remote_socket' => '127.0.0.1:19999']);
         $client->get('/', []);
@@ -96,11 +94,10 @@ class SocketHttpClientTest extends BaseTestCase
         $this->assertEquals(200, $response->getStatusCode());
     }
 
-    /**
-     * @expectedException \Http\Client\Socket\Exception\NetworkException
-     */
     public function testNetworkExceptionOnConnectError()
     {
+        $this->expectException(\Http\Client\Socket\Exception\NetworkException::class);
+
         $client = $this->createClient(['remote_socket' => '127.0.0.1:19999']);
         $client->get('/', []);
     }
@@ -174,22 +171,19 @@ class SocketHttpClientTest extends BaseTestCase
         $this->assertEquals(403, $response->getStatusCode());
     }
 
-    /**
-     * @expectedException \Http\Client\Socket\Exception\NetworkException
-     */
     public function testNetworkExceptionOnSslError()
     {
-        $this->startServer('tcp-server');
+        $this->expectException(\Http\Client\Socket\Exception\NetworkException::class);
 
+        $this->startServer('tcp-server');
         $client = $this->createClient(['remote_socket' => '127.0.0.1:19999', 'ssl' => true]);
         $client->get('/', []);
     }
 
-    /**
-     * @expectedException \Http\Client\Socket\Exception\TimeoutException
-     */
     public function testNetworkExceptionOnTimeout()
     {
+        $this->expectException(\Http\Client\Socket\Exception\TimeoutException::class);
+
         $client = $this->createClient(['timeout' => 1]);
         $response = $client->get('https://php.net', []);
         $response->getBody()->getContents();

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -109,11 +109,10 @@ class StreamTest extends TestCase
         $this->assertTrue($stream->isReadable());
     }
 
-    /**
-     * @expectedException \Http\Client\Socket\Exception\TimeoutException
-     */
     public function testTimeout()
     {
+        $this->expectException(\Http\Client\Socket\Exception\TimeoutException::class);
+
         $socket = fsockopen('php.net', 80);
         socket_set_timeout($socket, 0, 100);
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?         | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| Documentation   | if this is a new feature, link to pull request in https://github.com/php-http/documentation that adds relevant documentation
| License         | MIT


#### What's in this PR?

There are 5 tests using deprecated test annotations and although they are not an issue right now, they are quite annoying when you are working with the library development. This PR replaces the deprecated annotations with the proper assertions.

```
1) Http\Client\Socket\Tests\SocketHttpClientTest::testNoRemote
The @expectedException, @expectedExceptionCode, @expectedExceptionMessage, and @expectedExceptionMessageRegExp annotations are deprecated. They will be removed in PHPUnit 9. Refactor your test to use expectException(), expectExceptionCode(), expectExceptionMessage(), or expectExceptionMessageMatches() instead.

2) Http\Client\Socket\Tests\SocketHttpClientTest::testBrokenSocket
The @expectedException, @expectedExceptionCode, @expectedExceptionMessage, and @expectedExceptionMessageRegExp annotations are deprecated. They will be removed in PHPUnit 9. Refactor your test to use expectException(), expectExceptionCode(), expectExceptionMessage(), or expectExceptionMessageMatches() instead.

3) Http\Client\Socket\Tests\SocketHttpClientTest::testNetworkExceptionOnConnectError
The @expectedException, @expectedExceptionCode, @expectedExceptionMessage, and @expectedExceptionMessageRegExp annotations are deprecated. They will be removed in PHPUnit 9. Refactor your test to use expectException(), expectExceptionCode(), expectExceptionMessage(), or expectExceptionMessageMatches() instead.

4) Http\Client\Socket\Tests\SocketHttpClientTest::testNetworkExceptionOnSslError
The @expectedException, @expectedExceptionCode, @expectedExceptionMessage, and @expectedExceptionMessageRegExp annotations are deprecated. They will be removed in PHPUnit 9. Refactor your test to use expectException(), expectExceptionCode(), expectExceptionMessage(), or expectExceptionMessageMatches() instead.

5) Http\Client\Socket\Tests\StreamTest::testTimeout
The @expectedException, @expectedExceptionCode, @expectedExceptionMessage, and @expectedExceptionMessageRegExp annotations are deprecated. They will be removed in PHPUnit 9. Refactor your test to use expectException(), expectExceptionCode(), expectExceptionMessage(), or expectExceptionMessageMatches() instead.
```

#### Why?

Why not?


#### Checklist

- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)

^ This PR does not change the library itself and I could not find anything like that on the CHANGELOG.md, therefore I have updated it nor documented it anywhere else to be honest.