### PR TITLE
fix: allow configuration of php-http/socket-client >=2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.0.5 (unreleased)
 
+* Fixed constructor to work nicely with version 1 style arguments (e.g. HttplugBundle)
 * Fixed PHP 8 compatibility for stream timeouts
 * Renamed `master` branch to `2.x` for semantic branch naming.
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,21 +10,6 @@ parameters:
             path: src/RequestWriter.php
 
         -
-            message: "#^Constructor of class Http\\\\Client\\\\Socket\\\\Client has an unused parameter \\$config2\\.$#"
-            count: 1
-            path: src/Client.php
-
-        -
-            message: "#^Method Http\\\\Client\\\\Socket\\\\Client\\:\\:__construct\\(\\) has parameter \\$config1 with no type specified\\.$#"
-            count: 1
-            path: src/Client.php
-
-        -
-            message: "#^Method Http\\\\Client\\\\Socket\\\\Client\\:\\:__construct\\(\\) has parameter \\$config2 with no type specified\\.$#"
-            count: 1
-            path: src/Client.php
-
-        -
             message: "#^Method Http\\\\Client\\\\Socket\\\\Client\\:\\:configure\\(\\) should return array\\{remote_socket\\: string\\|null, timeout\\: int, stream_context\\: resource, stream_context_options\\: array\\<string, mixed\\>, stream_context_param\\: array\\<string, mixed\\>, ssl\\: bool\\|null, write_buffer_size\\: int, ssl_method\\: int\\} but returns array\\.$#"
             count: 1
             path: src/Client.php

--- a/src/Client.php
+++ b/src/Client.php
@@ -8,6 +8,7 @@ use Http\Client\Socket\Exception\InvalidRequestException;
 use Http\Client\Socket\Exception\SSLConnectionException;
 use Http\Client\Socket\Exception\TimeoutException;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -32,7 +33,9 @@ class Client implements HttpClient
     /**
      * Constructor.
      *
-     * @param array{remote_socket?: string|null, timeout?: int, stream_context?: resource, stream_context_options?: array<string, mixed>, stream_context_param?: array<string, mixed>, ssl?: ?boolean, write_buffer_size?: int, ssl_method?: int} $config
+     * @param array{remote_socket?: string|null, timeout?: int, stream_context?: resource, stream_context_options?: array<string, mixed>, stream_context_param?: array<string, mixed>, ssl?: ?boolean, write_buffer_size?: int, ssl_method?: int}|ResponseFactoryInterface $config1
+     * @param array{remote_socket?: string|null, timeout?: int, stream_context?: resource, stream_context_options?: array<string, mixed>, stream_context_param?: array<string, mixed>, ssl?: ?boolean, write_buffer_size?: int, ssl_method?: int}|null                     $config2 Mistake when refactoring the constructor from version 1 to version 2 - used as $config if set and $configOrResponseFactory is a response factory instance
+     * @param array{remote_socket?: string|null, timeout?: int, stream_context?: resource, stream_context_options?: array<string, mixed>, stream_context_param?: array<string, mixed>, ssl?: ?boolean, write_buffer_size?: int, ssl_method?: int}                          $config  intended for version 1 BC, used as $config if $config2 is not set and $configOrResponseFactory is a response factory instance
      *
      * string|null          remote_socket          Remote entrypoint (can be a tcp or unix domain address)
      * int                  timeout                Timeout before canceling request
@@ -51,9 +54,9 @@ class Client implements HttpClient
             return;
         }
 
-        @trigger_error('Passing a Psr\Http\Message\ResponseFactoryInterface and a Psr\Http\Message\StreamFactoryInterface to SocketClient is deprecated, and will be removed in 3.0, you should only pass config options.', E_USER_DEPRECATED);
+        @trigger_error('Passing a Psr\Http\Message\ResponseFactoryInterface to SocketClient is deprecated, and will be removed in 3.0, you should only pass config options.', E_USER_DEPRECATED);
 
-        $this->config = $this->configure($config);
+        $this->config = $this->configure($config2 ?: $config);
     }
 
     /**


### PR DESCRIPTION
wrap up #62 - Allow configuration of php-http/socket-client >=2.0 with HttplugBundle

fix #62